### PR TITLE
Make Abaqus formulations compatible with initial stresses.

### DIFF
--- a/Abaqus/UVCplanestress.for
+++ b/Abaqus/UVCplanestress.for
@@ -34,7 +34,7 @@ C
       REAL(8), DIMENSION(:, :), ALLOCATABLE :: alpha_k, alpha_k_i
       REAL(8), DIMENSION(:), ALLOCATABLE :: C_k, gamma_k
       ! Tensors
-      REAL(8), DIMENSION(3) :: strain_plastic,
+      REAL(8), DIMENSION(3) :: strain_plastic, dstran_p,
      1alpha, gamma_diag, alpha_tilde,alpha_tilde_prime,
      2strain, eta, eta_tilde, eta_trial, stress_trial,
      3gamma_prime_diag, stress_rel
@@ -139,7 +139,8 @@ C
 C ----------------------------------------------------------------------C
       ! Don't include e33, and calculate it later
       strain = stran + dstran
-      stress_trial = MATMUL(elastic_matrix, strain - strain_plastic)
+      stress_trial = stress + MATMUL(elastic_matrix, dstran)
+      !stress_trial = MATMUL(elastic_matrix, strain - strain_plastic)
 C
       hard_iso_Q = q_inf * (ONE - EXP(-b * ep_eq))
       hard_iso_D = d_inf * (ONE - EXP(-a * ep_eq))
@@ -258,9 +259,12 @@ C
      1      stress_rel(j)/hard_iso_total * c_k(i)/gamma_k(i)*(ONE-e_k)
           END DO
         END DO
-        strain_plastic = strain_plastic
-     1  + consist_param * MATMUL(P_mat, stress_rel)
-        stress = MATMUL(elastic_matrix, strain - strain_plastic)
+C        strain_plastic = strain_plastic
+C     1  + consist_param * MATMUL(P_mat, stress_rel)
+C        stress = MATMUL(elastic_matrix, strain - strain_plastic)
+        dstran_p = consist_param * MATMUL(P_mat, stress_rel)
+        strain_plastic = strain_plastic + dstran_p
+        stress = stress_trial - MATMUL(elastic_matrix, dstran_p)
       END IF
 C ----------------------------------------------------------------------C
 C

--- a/Abaqus/testing/Cube_Cyclic_Disp2.inp
+++ b/Abaqus/testing/Cube_Cyclic_Disp2.inp
@@ -15,7 +15,7 @@
       6,           0.,           0.,           1.
       7,           0.,           1.,           0.
       8,           0.,           0.,           0.
-*Element, type=C3D8
+*Element, type=C3D8R
 1, 5, 6, 8, 7, 1, 2, 4, 3
 *Nset, nset=Set-1, generate
  1,  8,  1
@@ -71,8 +71,8 @@ _Surf-1_S2, S2
 *Surface, type=ELEMENT, name=Surf-2
 _Surf-2_S6, S6
 *End Assembly
-*Amplitude, name=load_path, definition=EQUALLY SPACED, fixed interval=1.
-             0.,             0.3,           -0.15,            0.15,            -0.3,             0.3
+*Amplitude, name=load_path, definition=EQUALLY SPACED, fixed interval=0.2
+ 0., 1.0, 1.5, -1.5, 2.0, -2.0, 0.
 ** 
 ** MATERIALS
 ** 
@@ -83,7 +83,6 @@ _Surf-2_S6, S6
  318.5, 11608.2,   145.2,  1026.3,     4.7
 *Cyclic Hardening, parameters
  318.5, 100.7,    8.
-**
 ** BOUNDARY CONDITIONS
 ** 
 ** Name: bottom_fix Type: Displacement/Rotation
@@ -103,18 +102,18 @@ Set-11, 3, 3
 ** 
 ** STEP: loading
 ** 
-*Step, name=loading, nlgeom=YES, inc=100000
+*Step, name=loading, nlgeom=NO, inc=100000
 *Static
-0.01, 5., 5e-10, 0.01
+0.005, 1.2, 5e-10, 0.005
 ** 
 ** BOUNDARY CONDITIONS
 ** 
 ** Name: face_load Type: Displacement/Rotation
-*Boundary, amplitude=load_path
-Set-3, 2, 2, 0.5
+*Cload, amplitude=load_path
+Set-3, 2, 79.625
 ** Name: face_load_x Type: Displacement/Rotation
-*Boundary, amplitude=load_path
-Set-7, 1, 1, 0.5
+** *Boundary, amplitude=load_path
+** Set-7, 1, 1, 0.5
 ** 
 ** CONTROLS
 ** 
@@ -137,7 +136,7 @@ Set-7, 1, 1, 0.5
 ** 
 ** FIELD OUTPUT: F-Output-1
 ** 
-*Output, field, time interval=0.01
+*Output, field, time interval=0.005
 *Node Output
 CF, RF, U
 *Element Output, directions=YES

--- a/Abaqus/testing/Cube_Cyclic_Force.inp
+++ b/Abaqus/testing/Cube_Cyclic_Force.inp
@@ -15,7 +15,7 @@
       6,           0.,           0.,           1.
       7,           0.,           1.,           0.
       8,           0.,           0.,           0.
-*Element, type=C3D8
+*Element, type=C3D8R
 1, 5, 6, 8, 7, 1, 2, 4, 3
 *Nset, nset=Set-1, generate
  1,  8,  1
@@ -71,8 +71,8 @@ _Surf-1_S2, S2
 *Surface, type=ELEMENT, name=Surf-2
 _Surf-2_S6, S6
 *End Assembly
-*Amplitude, name=load_path, definition=EQUALLY SPACED, fixed interval=1.
-             0.,             0.3,           -0.15,            0.15,            -0.3,             0.3
+*Amplitude, name=load_path, definition=EQUALLY SPACED, fixed interval=0.2
+ 0., 1.0, 1.5, -1.5, 2.0, -2.0, 0.
 ** 
 ** MATERIALS
 ** 
@@ -83,7 +83,6 @@ _Surf-2_S6, S6
  318.5, 11608.2,   145.2,  1026.3,     4.7
 *Cyclic Hardening, parameters
  318.5, 100.7,    8.
-**
 ** BOUNDARY CONDITIONS
 ** 
 ** Name: bottom_fix Type: Displacement/Rotation
@@ -103,18 +102,15 @@ Set-11, 3, 3
 ** 
 ** STEP: loading
 ** 
-*Step, name=loading, nlgeom=YES, inc=100000
+*Step, name=loading, nlgeom=NO, inc=100000
 *Static
-0.01, 5., 5e-10, 0.01
+0.005, 1.2, 5e-10, 0.005
 ** 
 ** BOUNDARY CONDITIONS
 ** 
 ** Name: face_load Type: Displacement/Rotation
-*Boundary, amplitude=load_path
-Set-3, 2, 2, 0.5
-** Name: face_load_x Type: Displacement/Rotation
-*Boundary, amplitude=load_path
-Set-7, 1, 1, 0.5
+*Cload, amplitude=load_path
+Set-3, 2, 79.625
 ** 
 ** CONTROLS
 ** 
@@ -137,7 +133,7 @@ Set-7, 1, 1, 0.5
 ** 
 ** FIELD OUTPUT: F-Output-1
 ** 
-*Output, field, time interval=0.01
+*Output, field, time interval=0.005
 *Node Output
 CF, RF, U
 *Element Output, directions=YES

--- a/OpenSees/testing/3d_Brick_Test.tcl
+++ b/OpenSees/testing/3d_Brick_Test.tcl
@@ -43,7 +43,7 @@ pattern Plain 1 1 {
 # analysis
 set dt 0.005
 constraints Transformation
-test        NormDispIncr 1e-5 50 1
+test        NormDispIncr 1e-8 50 1
 algorithm   Newton
 numberer    Plain
 system      BandGeneral


### PR DESCRIPTION
Fix #11 

- Modify UVCmultiaxial and UVCplanestress abaqus implementations
- Fix cube testing for abaqus
- Add brick testing for opensees